### PR TITLE
refactor: change how to save start and end date

### DIFF
--- a/eoldiscussion/__init__.py
+++ b/eoldiscussion/__init__.py
@@ -13,6 +13,7 @@ from django.conf import settings as dsettings
 from django.contrib.auth.models import User
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import reverse
+from django.utils import timezone
 from eol_forum_notifications.utils import get_user_data
 from mako.lookup import TemplateLookup
 from six.moves import urllib
@@ -60,13 +61,13 @@ class EolDiscussionXBlock(DiscussionXBlock):
     start_date = String(
         display_name=_("Fecha de inicio"),
         scope=Scope.settings,
-        help=_("Indica la fecha de inicio del foro (horario chileno)")
+        help=_("Indica la fecha de inicio del foro")
     )
 
     end_date = String(
         display_name=_("Fecha de cierre"),
         scope=Scope.settings,
-        help=_("Indica la fecha de cierre del foro (horario chileno)")
+        help=_("Indica la fecha de cierre del foro")
     )
 
     editable_fields = ["display_name", "discussion_category", "discussion_target", "limit_character", "is_dated", "start_date", "end_date"]
@@ -176,24 +177,13 @@ class EolDiscussionXBlock(DiscussionXBlock):
             'include_mako_static': lambda path: self.include_mako_static(path, context)
         }
         if self.is_dated:
-            from django.utils import timezone
-            #edit the code below according to your time zone
-            zone = '-04:00'
-            if dsettings.USER_API_DEFAULT_PREFERENCES.get('time_zone', 'America/Santiago') == 'America/Santiago':
-                zone = '-03:00'
-            dt1 = dt.fromisoformat('{}{}'.format(self.start_date, zone))
-            dt2 = dt.fromisoformat('{}{}'.format(self.end_date, zone))
-            context['start'] = '{}{}'.format(self.start_date, zone)
-            context['finish'] = '{}{}'.format(self.end_date, zone)
+            dt1 = dt.fromisoformat(self.start_date.replace("Z", "+00:00"))
+            dt2 = dt.fromisoformat(self.end_date.replace("Z", "+00:00"))
+            context['start'] = self.start_date
+            context['finish'] = self.end_date
             now = timezone.now()
-            if dt1 > now:
-                context['started'] = False
-            else:
-                context['started'] = True
-            if dt2 < now:
-                context['finished'] = True
-            else:
-                context['finished'] = False
+            context['started'] = dt1 <= now
+            context['finished'] =  dt2 < now
         try:
             notification_data = get_user_data(self.discussion_id, self.django_user, self.course_key, self.location)
             context['url_eol_notification_save'] = reverse('eol_discussion_notification:save')
@@ -270,8 +260,8 @@ class EolDiscussionXBlock(DiscussionXBlock):
                 return 'Falta definir las fechas del foro.'
             else:
                 try:
-                    dt1 = dt.strptime(data.get('start_date', ''), "%Y-%m-%dT%H:%M")
-                    dt2 = dt.strptime(data.get('end_date', ''), "%Y-%m-%dT%H:%M")
+                    dt1 = dt.strptime(data.get('start_date', ''), "%Y-%m-%dT%H:%M:%S.%fZ")
+                    dt2 = dt.strptime(data.get('end_date', ''), "%Y-%m-%dT%H:%M:%S.%fZ")
                     if dt2 < dt1:
                         log.error('EolDiscussion - Error, end_date must be greatest than start_date, params: {}'.format(data))
                         return 'La fecha de cierre debe ser mayor a la fecha de inicio del foro.'

--- a/eoldiscussion/static/html/studio_edit.html
+++ b/eoldiscussion/static/html/studio_edit.html
@@ -45,15 +45,15 @@
     </li>
     <li class="field comp-setting-entry is-set" id="li_start_date">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="start_date">{{fields.start_date.display_name}}</label>
-        <input class="input setting-input" name="start_date" id="start_date" value="{{xblock.start_date}}" type="datetime-local" />
+        <label class="label setting-label" for="start_date">{{fields.start_date.display_name}}<span class="user-timezone"></span></label>
+        <input class="input setting-input" name="start_date" id="start_date" value="{{xblock.start_date}}" type="datetime-local" data-start-date="{{xblock.start_date}}"/>
       </div>
       <span class="tip setting-help">{{fields.start_date.help|safe}}</span>
     </li>
     <li class="field comp-setting-entry is-set" id="li_end_date">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="end_date">{{fields.end_date.display_name}}</label>
-        <input class="input setting-input" name="end_date" id="end_date" value="{{xblock.end_date}}" type="datetime-local" />
+        <label class="label setting-label" for="end_date">{{fields.end_date.display_name}}<span class="user-timezone"></span></label>
+        <input class="input setting-input" name="end_date" id="end_date" value="{{xblock.end_date}}" type="datetime-local" data-end-date="{{xblock.end_date}}"/>
       </div>
       <span class="tip setting-help">{{fields.end_date.help|safe}}</span>
     </li>

--- a/eoldiscussion/static/js/studio_edit.js
+++ b/eoldiscussion/static/js/studio_edit.js
@@ -1,7 +1,9 @@
 /* Javascript for StudioEditableXBlockMixin. */
 function StudioEditableXBlockMixin(runtime, element, settings) {
     "use strict";
+    const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     $(function($) {
+        $(element).find(".user-timezone").text(` (${userTimeZone})`);
         if(settings.is_dated){
             $(element).find('#li_start_date').show();
             $(element).find('#li_end_date').show();
@@ -10,6 +12,16 @@ function StudioEditableXBlockMixin(runtime, element, settings) {
             $(element).find('#li_start_date').hide();
             $(element).find('#li_end_date').hide();
         }
+        require(['moment-timezone'], function (moment) {
+            var el_start_date = $(element).find('#start_date');
+            if (el_start_date.data('start-date') != "None") {
+                el_start_date.val(moment.utc( el_start_date.data('start-date')).tz(userTimeZone).format('YYYY-MM-DD HH:mm'));
+            }
+            var el_end_date = $(element).find('#end_date');
+            if (el_end_date.data('end-date') != "None") {
+                el_end_date.val(moment.utc( el_end_date.data('end-date')).tz(userTimeZone).format('YYYY-MM-DD HH:mm'));
+            }
+        });
     });
     $(element).find('#is_dated').on('change', function() {
         //0: disabled
@@ -84,22 +96,24 @@ function StudioEditableXBlockMixin(runtime, element, settings) {
             if(end_date > start_date) check = true;
         }
         if(!check){
-            runtime.notify('error', {title: gettext("Unable to update settings"), message: 'Revise quelos parámetros enten correctos.'});
+            runtime.notify('error', {title: gettext("Unable to update settings"), message: 'Revise que los parámetros enten correctos.'});
         }
         else{
-            $(element).find('#limit_character')[0].value = limit.toString();
-            var offset = new Date().getTimezoneOffset();
-            var timezone = -(offset/60)
-            var form_data = {
-                'display_name': $(element).find('input[name=display_name]').val(),
-                'discussion_category': $(element).find('input[name=discussion_category]').val(),
-                'discussion_target': $(element).find('input[name=discussion_target]').val(),
-                'limit_character': $(element).find('input[name=limit_character]').val(),
-                'is_dated': is_dated,
-                'start_date': $(element).find('input[name=start_date]').val(),
-                'end_date': $(element).find('input[name=end_date]').val()
-            }
-            studio_submit(form_data);
+            require(['moment-timezone'], function (moment) {
+                $(element).find('#limit_character')[0].value = limit.toString();
+                var start_date = moment($(element).find('input[name=start_date]').val()).tz(userTimeZone).utc().toISOString()
+                var end_date = moment($(element).find('input[name=end_date]').val()).tz(userTimeZone).utc().toISOString()
+                var form_data = {
+                    'display_name': $(element).find('input[name=display_name]').val(),
+                    'discussion_category': $(element).find('input[name=discussion_category]').val(),
+                    'discussion_target': $(element).find('input[name=discussion_target]').val(),
+                    'limit_character': $(element).find('input[name=limit_character]').val(),
+                    'is_dated': is_dated,
+                    'start_date': start_date,
+                    'end_date': end_date
+                }
+                studio_submit(form_data);
+            })
         }
     });
 

--- a/eoldiscussion/tests.py
+++ b/eoldiscussion/tests.py
@@ -347,8 +347,8 @@ class EolDiscussionXBlockImportExportTests(UrlResetMixin, ModuleStoreTestCase):
             'discussion_target': 'test_target',
             'limit_character': 1200,
             'is_dated': True,
-            'start_date':'2025-04-28T14:30',
-            'end_date':'2025-03-28T14:30',
+            'start_date':'2025-04-28T14:30:00.000Z',
+            'end_date':'2025-03-28T14:30:00.000Z',
         })
 
         request.body = data.encode()
@@ -368,8 +368,8 @@ class EolDiscussionXBlockImportExportTests(UrlResetMixin, ModuleStoreTestCase):
             'discussion_target': 'test_target',
             'limit_character': 1200,
             'is_dated': True,
-            'start_date':'2025-03-28T14:30',
-            'end_date':'2025-04-28T14:30',
+            'start_date':'2025-03-28T14:30:00.000Z',
+            'end_date':'2025-04-28T14:30:00.000Z',
         })
         request.body = data.encode()
         response = self.xblock.submit_studio_edits(request)
@@ -424,8 +424,8 @@ class EolDiscussionXBlockImportExportTests(UrlResetMixin, ModuleStoreTestCase):
         self.xblock.scope_ids.usage_id = mock.Mock()
         self.xblock.scope_ids.usage_id.course_key = self.course.id
         self.xblock.is_dated = True
-        self.xblock.start_date = '2024-12-01T08:00:00'
-        self.xblock.end_date = '2024-12-01T17:00:00'
+        self.xblock.start_date = '2024-12-01T08:00:00.000Z'
+        self.xblock.end_date = '2024-12-01T17:00:00.000Z'
         student_view = self.xblock.student_view()
         student_view_html = student_view.content
         self.assertIn('discussion-module eoldiscussion-module', student_view_html)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, roots):
 
 setup(
     name='eoldiscussion-xblock',
-    version='1.2.0',
+    version='1.3.0',
     description='EOL Discussion Xblock',
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",


### PR DESCRIPTION
Se actualiza la forma en la que se guarda la fecha, se guarda en utc, dada las instrucciones se pasa la fecha a america santiago y luego se guarda en utc, luego al mostrara para editar de hace el ejercicios contrario, pase de utc a america/sanitago